### PR TITLE
Tolerate non-SUCCESS `code` in ClientController

### DIFF
--- a/mock/mappings/createCashBackRequest.json
+++ b/mock/mappings/createCashBackRequest.json
@@ -4,7 +4,7 @@
         "urlPath": "/v2/cashback"
     },
     "response": {
-        "status": 201,
+        "status": 202,
         "headers": {
             "Content-Type": "application/json"
         },

--- a/mock/mappings/getCashbackDetails_200_NOT_ENOUGH_MONEY.json
+++ b/mock/mappings/getCashbackDetails_200_NOT_ENOUGH_MONEY.json
@@ -1,0 +1,35 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPath": "/v2/cashback/test-not-enough-money"
+    },
+    "response": {
+        "status": 200,
+        "headers": {
+            "Content-Type": "application/json"
+        },
+        "jsonBody": {
+            "resultInfo": {
+                "code": "NOT_ENOUGH_MONEY",
+                "message": "Not enough balance in the campaign budget to complete the cashback transaction",
+                "codeId": "WAL_500017"
+            },
+            "data": {
+                "status": "FAILURE",
+                "acceptedAt": 1634012345,
+                "merchantAlias": "000000000000000000",
+                "amount": {
+                    "amount": 100000,
+                    "currency": "JPY"
+                },
+                "requestedAt": 1601912345,
+                "metadata": {},
+                "cashbackId": "00000000000000009999",
+                "merchantCashbackId": "test-not-enough-money",
+                "userAuthorizationId": "00000000-0000-0000-0000-000000000000",
+                "orderDescription": "order description",
+                "walletType": "PREPAID"
+            }
+        }
+    }
+}

--- a/mock/mappings/getCashbackDetails_200_SUCCESS.json
+++ b/mock/mappings/getCashbackDetails_200_SUCCESS.json
@@ -1,10 +1,10 @@
 {
     "request": {
         "method": "GET",
-        "urlPath": "/v2/cashback/testXXXXXXXXXXXXXXX123"
+        "urlPath": "/v2/cashback/test-success"
     },
     "response": {
-        "status": 201,
+        "status": 200,
         "headers": {
             "Content-Type": "application/json"
         },
@@ -24,9 +24,9 @@
                 },
                 "requestedAt": 1611747650,
                 "metadata": "",
-                "cashbackId": "test",
-                "merchantCashbackId": "test",
-                "userAuthorizationId": "test",
+                "cashbackId": "00000000000000001111",
+                "merchantCashbackId": "test-success",
+                "userAuthorizationId": "00000000-0000-0000-0000-000000000000",
                 "orderDescription": "order description",
                 "walletType": "PREPAID"
             }

--- a/src/core/Controller.php
+++ b/src/core/Controller.php
@@ -167,7 +167,7 @@ class Controller
      */
     protected function parseResultInfo($apiInfo, $resultInfo, $statusCode)
     {
-        if (strcmp($resultInfo['code'], "SUCCESS") !== 0 && strcmp($resultInfo['code'], "REQUEST_ACCEPTED")) {
+        if ($statusCode >= 400) {
             throw new ClientControllerException(
                 $apiInfo,
                 $resultInfo, //PayPay API message

--- a/tests/CashbackTest.php
+++ b/tests/CashbackTest.php
@@ -7,87 +7,91 @@ require_once('TestBoilerplate.php');
 final class CashbackTest extends BoilerplateTest
 {
     /**
-     * Give cashback
+     * Tests giveCashback
      *
      * @return void
      */
-    public function GiveCashBack()
+    public function testGiveCashBack()
     {
         $this->InitCheck();
         $client = $this->client;
-        $merchatCashbackId = "testXXXXXXXXXXXXXXX123";
+        $merchantCashbackId = "testXXXXXXXXXXXXXXX123";
         $amount = [
             "amount" => 1,
             "currency" => "JPY"
         ];
         $CPPayload = new CashBackPayload();
-        $CPPayload->setMerchantCashbackId($merchatCashbackId)->setRequestedAt()->setUserAuthorizationId($this->config['uaid'])->setAmount($amount);
+        $CPPayload->setMerchantCashbackId($merchantCashbackId)->setRequestedAt()->setUserAuthorizationId($this->config['uaid'])->setAmount($amount);
         $resp = $client->cashback->giveCashback($CPPayload);
         $resultInfo = $resp['resultInfo'];
         $this->assertEquals('REQUEST_ACCEPTED', $resultInfo['code']);
-        $tempMerchatCashbackId = $merchatCashbackId;
-        $this->data = $tempMerchatCashbackId;
+        $tempMerchantCashbackId = $merchantCashbackId;
+        $this->data = $tempMerchantCashbackId;
     }
 
     /**
-     * CheckCashBackDetails
+     * Tests getCashbackDetails when code is SUCCESS
      *
      * @return void
      */
-    public function CheckCashBackDetails()
+    public function testCheckCashBackDetailsSuccess()
     {
-        $merchatCashbackId = "testXXXXXXXXXXXXXXX123";
-        $resp = $this->client->cashback->getCashbackDetails($merchatCashbackId);
+        $merchantCashbackId = "test-success";
+        $resp = $this->client->cashback->getCashbackDetails($merchantCashbackId);
         $resultInfo = $resp['resultInfo'];
         $this->assertEquals('SUCCESS', $resultInfo['code']);
+        $this->assertEquals('00000000000000001111', $resp['data']['cashbackId']);
+        $this->assertEquals(1, $resp['data']['amount']['amount']);
     }
 
     /**
-    * Give ReversalCashBack
+     * Tests getCashbackDetails when code is NOT_ENOUGH_MONEY
+     *
+     * @return void
+     */
+    public function testCheckCashBackDetailsNotEnoughMoney()
+    {
+        $merchantCashbackId = "test-not-enough-money";
+        $resp = $this->client->cashback->getCashbackDetails($merchantCashbackId);
+        $resultInfo = $resp['resultInfo'];
+        $this->assertEquals('NOT_ENOUGH_MONEY', $resultInfo['code']);
+        $this->assertEquals('00000000000000009999', $resp['data']['cashbackId']);
+        $this->assertEquals(100000, $resp['data']['amount']['amount']);
+    }
+
+    /**
+    * Tests reverseCashBack
     *
     * @return void
     */
-    public function ReversalCashBack()
+    public function testReversalCashBack()
     {
         $client = $this->client;
         $merchantCashbackReversalId = "TESTXXXXXXXXX456";
-        $merchatCashbackId = "testXXXXXXXXXXXXXXX123";
+        $merchantCashbackId = "testXXXXXXXXXXXXXXX123";
         $reason = "reason";
         $amount = [
             "amount" => 1,
             "currency" => "JPY"
         ];
         $CPPayload = new ReverseCashBackPayload();
-        $CPPayload->setMerchantCashbackReversalId($merchantCashbackReversalId)->setMerchantCashbackId($merchatCashbackId)->setRequestedAt()->setReason($reason)->setAmount($amount);
+        $CPPayload->setMerchantCashbackReversalId($merchantCashbackReversalId)->setMerchantCashbackId($merchantCashbackId)->setRequestedAt()->setReason($reason)->setAmount($amount);
         $resp = $client->cashback->reverseCashBack($CPPayload);
         $resultInfo = $resp['resultInfo'];
         $this->assertEquals('REQUEST_ACCEPTED', $resultInfo['code']);
     }
 
     /**
-     * CheckCashBackDetails
+     * Tests giveReversalCashbackDetails
      *
      * @return void
      */
-    public function CheckReversalCashBackDetails()
+    public function testCheckReversalCashBackDetails()
     {
         $merchantCashbackReversalId = "TESTXXXXXXXXX456";
-        $merchatCashbackId = "testXXXXXXXXXXXXXXX123";
-        $resp = $this->client->cashback->getReversalCashbackDetails($merchantCashbackReversalId, $merchatCashbackId);
+        $merchantCashbackId = "testXXXXXXXXXXXXXXX123";
+        $resp = $this->client->cashback->getReversalCashbackDetails($merchantCashbackReversalId, $merchantCashbackId);
         $resultInfo = $resp['resultInfo'];
         $this->assertEquals('SUCCESS', $resultInfo['code']);
-    }
-    
-    /**
-     * tests Create And Cancel
-     *
-     * @return void
-     */
-    public function testCreateAndCancel()
-    {
-        $this->GiveCashBack();
-        $this->CheckCashBackDetails();
-        $this->ReversalCashBack();
-        $this->CheckReversalCashBackDetails();
     }
 }


### PR DESCRIPTION
Some APIs return codes other than `SUCCESS` and `REQUEST_ACCEPTED` when successful.

This PR modifies the `ClientController` to only throw `ClientControllerException` when the HTTP status code is a `4XX` or `5XX`, rather than based on the `resultInfo.code`.

This PR is a breaking change for clients that previously expected an exception to be thrown for `NOT_ENOUGH_MONEY`/`INTERNAL_SERVER_ERROR`/`BALANCE_OUT_OF_LIMIT` responses for the get-cashback-details API.

This change makes the PHP SDK behave in-line with the other Node, Java, and Python SDKs.

Unit tests have been updated to include this case.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](../../paypayopa-sdk-php/blob/master/contributing.md) document?
* [ ] Have you read and signed the automated Contributor's License Agreement?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../paypayopa-sdk-php/pulls) for the same update/change?


### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
