### PR TITLE
Fix #152: Fix 401 unauthorized for `checkWalletBalance`

### DIFF
--- a/src/Controllers/Wallet.php
+++ b/src/Controllers/Wallet.php
@@ -41,9 +41,9 @@ class Wallet extends Controller
                 throw new ClientControllerException(false, "Invalid Direct Debit Product Type", 500);
             }
         }
-        $url = $this->api_url . $this->main()->GetEndpoint('WALLET_BALANCE');
+        $url = $this->api_url . $this->main()->GetEndpoint('WALLET_BALANCE') . '?' . http_build_query($data);
         $endpoint = '/v2' . $this->main()->GetEndpoint('WALLET_BALANCE');
-        $options = $this->HmacCallOpts('GET', $endpoint, 'application/json;charset=UTF-8;', $data);
+        $options = $this->HmacCallOpts('GET', $endpoint);
 
         return $this->doCall(true, "v2_checkWalletBalance", $url, [], $options);
     }


### PR DESCRIPTION
This PR fixes #152. `checkWalletBalance` will no longer throw a `ClientControllerException` when the `API_KEY`, `API_KEY_SECRET`, etc are correct.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](../../paypayopa-sdk-php/blob/master/contributing.md) document?
* [x] Have you read and signed the automated Contributor's License Agreement?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../paypayopa-sdk-php/pulls) for the same update/change?


### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
