### PR TITLE
Fix #245: Remove unnecessary print in ClientControllerException

### DIFF
--- a/src/core/ClientControllerException.php
+++ b/src/core/ClientControllerException.php
@@ -27,7 +27,6 @@ class ClientControllerException extends Exception
             // If string message error
             parent::__construct($resultInfo, $code);
         }
-        print("This link helps you to troubleshoot the issue: ".$this->getResolutionUrl());
     }
 
     /**


### PR DESCRIPTION
This PR removes an unnecessary invocation of `print` in the `ClientControllerException` constructor, fixing #245.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](../../paypayopa-sdk-php/blob/master/contributing.md) document?
* [ ] Have you read and signed the automated Contributor's License Agreement?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../paypayopa-sdk-php/pulls) for the same update/change?


### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
