### PR TITLE
use {$var} instead of ${var}

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -102,7 +102,7 @@ class Client
         $toStg = !$productionmode ? '-stg' : '';
         $toStg = $productionmode === 'test' ? '-test' : $toStg;
         $toStg = $productionmode === 'perfMode' ? '-perf' : $toStg;
-        $this->config = require(__DIR__ . "/conf/config${toStg}.php");
+        $this->config = require(__DIR__ . "/conf/config{$toStg}.php");
         $this->endpoints = require(__DIR__ . '/conf/endpoints.php');
         $this->apiMappings = require(__DIR__ . '/conf/apiMappings.php');
         $this->versions = require(__DIR__ . '/conf/apiVersions.php');

--- a/src/Controllers/Payment.php
+++ b/src/Controllers/Payment.php
@@ -265,7 +265,7 @@ class Payment extends Controller
         switch ($paymentType) {
             case 'pending':
                 $version = $this->main()->GetEndpointVersion('REQUEST_ORDER');
-                $endpoint = "/${version}" . $main->GetEndpoint('REQUEST_ORDER') . "/$merchantPaymentId";
+                $endpoint = "/{$version}" . $main->GetEndpoint('REQUEST_ORDER') . "/$merchantPaymentId";
                 $url = $this->api_url . $main->GetEndpoint('REQUEST_ORDER') . "/$merchantPaymentId";
                 $url = str_replace('v2', $version, $url);
                 break;

--- a/src/core/ClientControllerException.php
+++ b/src/core/ClientControllerException.php
@@ -42,6 +42,6 @@ class ClientControllerException extends Exception
         $code = $resultInfo["code"];
         $codeId = $resultInfo["codeId"];
         $apiName = $this->apiInfo["api_name"];
-        return "${documentationUrl}?api_name=${apiName}&code=${code}&code_id=${codeId}";
+        return "{$documentationUrl}?api_name={$apiName}&code={$code}&code_id={$codeId}";
     }
 }

--- a/src/core/Model.php
+++ b/src/core/Model.php
@@ -38,10 +38,10 @@ class Model
             }
             if ($memberInfo['type'] === 'string') {
                 if (strlen($member) < 1) {
-                    throw new ModelException("${memberName} cannot be empty", 1, [$memberName]);
+                    throw new ModelException("{$memberName} cannot be empty", 1, [$memberName]);
                 }
                 if (isset($memberInfo['strlen']) && $memberInfo['strlen'] !== 0 && strlen($member) > $memberInfo['strlen']) {
-                    throw new ModelException("${memberName} exceeds maximum size of  characters", 1, [$memberName]);
+                    throw new ModelException("{$memberName} exceeds maximum size of  characters", 1, [$memberName]);
                 }
             }
         }

--- a/tests/CoreClassesTest.php
+++ b/tests/CoreClassesTest.php
@@ -32,7 +32,7 @@ class CoreClassesTest extends BoilerplateTest
         $collector["ENDPOINT_VERSION"] = $client->GetEndpointVersion('SUBSCRIPTION');
         $collector["MERCHANT_ID"] = $client->GetMid();
         foreach ($collector as $key => $value) {
-            $this->assertNotNull($value, "${key} invalid");
+            $this->assertNotNull($value, "{$key} invalid");
         }
     }
     public function testClientBadNwClient()
@@ -68,7 +68,7 @@ class CoreClassesTest extends BoilerplateTest
         $collector["ENDPOINT_VERSION"] = $client->GetEndpointVersion('SUBSCRIPTION');
         $collector["MERCHANT_ID"] = $client->GetMid();
         foreach ($collector as $key => $value) {
-            $this->assertNotNull($value, "${key} invalid");
+            $this->assertNotNull($value, "{$key} invalid");
         }
     }
     public function testClientProduction()
@@ -87,7 +87,7 @@ class CoreClassesTest extends BoilerplateTest
         $collector["ENDPOINT_VERSION"] = $client->GetEndpointVersion('SUBSCRIPTION');
         $collector["MERCHANT_ID"] = $client->GetMid();
         foreach ($collector as $key => $value) {
-            $this->assertNotNull($value, "${key} invalid");
+            $this->assertNotNull($value, "{$key} invalid");
         }
     }
     public function testClientTestMode()
@@ -106,7 +106,7 @@ class CoreClassesTest extends BoilerplateTest
         $collector["ENDPOINT_VERSION"] = $client->GetEndpointVersion('SUBSCRIPTION');
         $collector["MERCHANT_ID"] = $client->GetMid();
         foreach ($collector as $key => $value) {
-            $this->assertNotNull($value, "${key} invalid");
+            $this->assertNotNull($value, "{$key} invalid");
         }
     }
     public function testClientNoMid()


### PR DESCRIPTION
Starting with PHP 8.2, there is a deprecated notation for embedding variables in strings
Reference: https://www.php.net/manual/en/migration82.deprecated.php

In this repository, there was an embedding using `${var}`, which has been corrected to {$var}. 


## All Submissions:
- [x] Have you followed the guidelines in our [Contributing](https://github.com/paypay/paypayopa-sdk-php/blob/master/contributing.md) document?
- [x] Have you read and signed the automated Contributor's License Agreement?
-  [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/paypay/paypayopa-sdk-php/pulls) for the same update/change?

## New Feature Submissions:
- [x] Does your submission pass tests?
- [x] Have you lint your code locally prior to submission?

## Changes to Core Features:
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?-
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?