### PR TITLE
Fix #394: feat: add paymentId parameter to getRefundDetails API

### DIFF
--- a/src/Controllers/Refund.php
+++ b/src/Controllers/Refund.php
@@ -45,13 +45,17 @@ class Refund extends Controller
     /**
      * Get refund details.
      * @param String $merchantRefundId The unique refund transaction id provided by merchant
+     * @param string $paymentId
      * @return array
      * @throws ClientControllerException
      */
-    public function getRefundDetails($merchantRefundId)
+    public function getRefundDetails($merchantRefundId, $paymentId)
     {
+        $data = [
+            'paymentId' => $paymentId
+        ];
         $main = $this->MainInst;
-        $url = $main->GetConfig('API_URL') . $main->GetEndpoint('REFUND') . "/$merchantRefundId";
+        $url = $main->GetConfig('API_URL') . $main->GetEndpoint('REFUND') . "/$merchantRefundId" . '?' . http_build_query($data);
         $endpoint = '/v2' . $main->GetEndpoint('REFUND') . "/$merchantRefundId";
         $options = $this->HmacCallOpts('GET', $endpoint);
 

--- a/tests/PendingPaymentTest.php
+++ b/tests/PendingPaymentTest.php
@@ -114,7 +114,8 @@ final class PendingPaymentTest extends BoilerplateTest
     public function refundDetails()
     {
         $merchantRefundId = $this->data['merchantRefundId'];
-        $resp = $this->client->refund->getRefundDetails($merchantRefundId);
+        $paymentId = $this->data['paymentId'];
+        $resp = $this->client->refund->getRefundDetails($merchantRefundId, $paymentId);
         $resultInfo = $resp['resultInfo'];
         $this->assertEquals('SUCCESS', $resultInfo['code']);
     }

--- a/tests/RefundTest.php
+++ b/tests/RefundTest.php
@@ -66,8 +66,8 @@ final class RefundTest extends BoilerplateTest
     public function refundDetails()
     {
         $merchantRefundId = $this->data['merchantRefundId'];
-        ;
-        $resp = $this->client->refund->getRefundDetails($merchantRefundId);
+        $paymentId = $this->data['paymentId'];
+        $resp = $this->client->refund->getRefundDetails($merchantRefundId, $paymentId);
         $resultInfo = $resp['resultInfo'];
         $this->assertEquals('SUCCESS', $resultInfo['code']);
     }


### PR DESCRIPTION
issue: https://github.com/paypay/paypayopa-sdk-php/issues/394

- Update Refund.getRefundDetails() method to require paymentId parameter
- Update RefundTest.php to pass paymentId parameter
- Update PendingPaymentTest.php to pass paymentId parameter
- Support PayPay Get Refund Details API specification changes

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](../../paypayopa-sdk-php/blob/master/contributing.md) document?
* [x] Have you read and signed the automated Contributor's License Agreement?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../paypayopa-sdk-php/pulls) for the same update/change?


### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
