### PR TITLE
GuzzleHttp to PSR-18 compatible client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,13 +47,19 @@
         "php": ">=7.0.0",
         "ext-json": "*",
         "firebase/php-jwt": "^5.5 || ^6.0",
-        "guzzlehttp/guzzle": "^6.0 || ^7.0"
+        "psr/http-client": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0"
+    },
+    "suggest": {
+        "guzzlehttp/guzzle": "^7.0 - PSR-18 implementation",
+        "symfony/http-client": "^6.0 || ^7.0 - PSR-18 implementation"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16 || ^3.0",
         "php-coveralls/php-coveralls": "^2.2",
         "phpstan/phpstan": "^0.12.33 || ^1.0.0",
-        "phpunit/phpunit": "^9"
+        "phpunit/phpunit": "^9",
+        "guzzlehttp/guzzle": "^7.0"
     },
     "scripts": {
         "test": "./vendor/bin/phpunit --testdox tests",

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,7 +2,7 @@
 
 namespace PayPay\OpenPaymentAPI;
 
-use GuzzleHttp\Client as GuzzleHttpClient;
+use Psr\Http\Client\ClientInterface;
 use PayPay\OpenPaymentAPI\Controller\Code;
 use PayPay\OpenPaymentAPI\Controller\Payment;
 use PayPay\OpenPaymentAPI\Controller\Refund;
@@ -43,9 +43,9 @@ class Client
      */
     private $versions;
     /**
-     * Guzzle client to handle http calls
+     * PSR Http compatible client to handle http calls
      *
-     * @var GuzzleHttpClient
+     * @var ClientInterface
      */
     private $requestHandler;
     /**
@@ -90,10 +90,10 @@ class Client
      * optional auth handler, and options
      * @param array|null $auth API credentials
      * @param boolean|string $productionmode Sandbox environment flag
-     * @param GuzzleHttpClient|boolean $requestHandler
+     * @param ClientInterface|null $requestHandler
      * @throws ClientException
      */
-    public function __construct($auth = null, $productionmode = false, $requestHandler = false)
+    public function __construct($auth = null, $productionmode = false, $requestHandler = null)
     {
         if (!isset($auth['API_KEY']) || !isset($auth['API_SECRET'])) {
             throw new ClientException("Invalid auth credentials", 1);
@@ -106,10 +106,10 @@ class Client
         $this->endpoints = require(__DIR__ . '/conf/endpoints.php');
         $this->apiMappings = require(__DIR__ . '/conf/apiMappings.php');
         $this->versions = require(__DIR__ . '/conf/apiVersions.php');
-        if (!$requestHandler) {
-            $this->requestHandler = new GuzzleHttpClient(['base_uri' => $this->config["API_URL"]]);
+        if ($requestHandler === null) {
+            $this->requestHandler = new \GuzzleHttp\Client(['base_uri' => $this->config["API_URL"]]);
         } else {
-            if ($requestHandler instanceof GuzzleHttpClient) {
+            if ($requestHandler instanceof ClientInterface) {
                 $this->requestHandler = $requestHandler;
             } else {
                 throw new ClientException('Invalid request handler.', 500);
@@ -189,7 +189,7 @@ class Client
     /**
      * get client request handler for controller
      *
-     * @return GuzzleHttpClient
+     * @return ClientInterface
      */
     public function http()
     {

--- a/src/Controllers/Payment.php
+++ b/src/Controllers/Payment.php
@@ -2,8 +2,8 @@
 
 namespace PayPay\OpenPaymentAPI\Controller;
 
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\RequestException;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
 use PayPay\OpenPaymentAPI\Client;
 use PayPay\OpenPaymentAPI\Models\CapturePaymentAuthPayload;
 use PayPay\OpenPaymentAPI\Models\CreateContinuousPaymentPayload;
@@ -41,7 +41,7 @@ class Payment extends Controller
      * @return array
      * @throws ClientControllerException
      * @throws ModelException
-     * @throws GuzzleException
+     * @throws ClientExceptionInterface
      */
     public function createPayment($payload, $agreeSimilarTransaction = false)
     {
@@ -147,7 +147,7 @@ class Payment extends Controller
      * @return array
      * @throws ClientControllerException
      * @throws ModelException
-     * @throws GuzzleException
+     * @throws ClientExceptionInterface
      */
     public function createPaymentAuth($payload, $agreeSimilarTransaction = false)
     {
@@ -220,7 +220,7 @@ class Payment extends Controller
      * @param array $data
      * @return array
      * @throws ClientControllerException
-     * @throws GuzzleException
+     * @throws ClientExceptionInterface
      */
     private function doSimilarTransactionCall($apiId, $url, $options, $data)
     {
@@ -240,7 +240,7 @@ class Payment extends Controller
                     'timeout' => $options['TIMEOUT']
                 ]
             );
-        } catch (RequestException $e) {
+        } catch (RequestExceptionInterface $e) {
             if ($e->hasResponse()) {
                 $response = $e->getResponse();
             }

--- a/src/Controllers/User.php
+++ b/src/Controllers/User.php
@@ -3,8 +3,8 @@
 namespace PayPay\OpenPaymentAPI\Controller;
 
 use Firebase\JWT;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\RequestException;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
 use PayPay\OpenPaymentAPI\Models\AccountLinkPayload;
 use PayPay\OpenPaymentAPI\Models\ModelException;
 
@@ -86,7 +86,7 @@ class User extends Controller
      * @param string $userAuthorizationId
      * @return array
      * @throws ClientControllerException
-     * @throws GuzzleException
+     * @throws ClientExceptionInterface
      */
     public function getUserAuthorizationStatus($userAuthorizationId)
     {
@@ -106,7 +106,7 @@ class User extends Controller
      * @param string $userAuthorizationId
      * @return array
      * @throws ClientControllerException
-     * @throws GuzzleException
+     * @throws ClientExceptionInterface
      */
     public function getMaskedUserProfile($userAuthorizationId)
     {
@@ -128,7 +128,7 @@ class User extends Controller
      * @param string $userAuthorizationId
      * @return array
      * @throws ClientControllerException
-     * @throws GuzzleException
+     * @throws ClientExceptionInterface
      */
     private function doAuthCall($apiId, $url, $options, $userAuthorizationId)
     {
@@ -141,7 +141,7 @@ class User extends Controller
                     'query' =>  ['userAuthorizationId' => $userAuthorizationId]
                 ]
             );
-        } catch (RequestException $e) {
+        } catch (RequestExceptionInterface $e) {
             if ($e->hasResponse()) {
                 $response = $e->getResponse();
             }

--- a/src/core/Controller.php
+++ b/src/core/Controller.php
@@ -2,7 +2,7 @@
 
 namespace PayPay\OpenPaymentAPI\Controller;
 
-use GuzzleHttp\Exception\RequestException;
+use Psr\Http\Client\RequestExceptionInterface;
 use PayPay\OpenPaymentAPI\Client;
 
 use function PayPay\OpenPaymentAPI\Helpers\PayPayEncryptHeader;
@@ -130,7 +130,8 @@ class Controller
         $response = null;
         try {
             if ($callType === 'post') {
-                $response = $request->$callType(
+                $response = $request->request(
+                    $callType,
                     $url,
                     [
                         'headers' => $options["HEADERS"],
@@ -140,14 +141,15 @@ class Controller
                 );
             }
             if ($callType === 'get' || $callType === 'delete') {
-                $response = $request->$callType(
+                $response = $request->request(
+                    $callType,
                     $url,
                     [
                         'headers' => $options["HEADERS"]
                     ]
                 );
             }
-        } catch (RequestException $e) {
+        } catch (RequestExceptionInterface $e) {
             if ($e->hasResponse()) {
                 $response = $e->getResponse();
             }


### PR DESCRIPTION
Refactored the HTTP layer to use a PSR-18 compatible client instead of being tightly coupled to Guzzle.

- Replaces direct Guzzle usage with PSR-18 interfaces
- Decouples the library from a specific HTTP client implementation
- Allows consumers to use custom HTTP clients (e.g. Symfony HttpClient) instead of Guzzle
- Improves flexibility and interoperability within the PHP ecosystem

