### PR TITLE
Deprecated "${var}" has been changed to "{$var}"

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -102,7 +102,7 @@ class Client
         $toStg = !$productionmode ? '-stg' : '';
         $toStg = $productionmode === 'test' ? '-test' : $toStg;
         $toStg = $productionmode === 'perfMode' ? '-perf' : $toStg;
-        $this->config = require(__DIR__ . "/conf/config${toStg}.php");
+        $this->config = require(__DIR__ . "/conf/config{$toStg}.php");
         $this->endpoints = require(__DIR__ . '/conf/endpoints.php');
         $this->apiMappings = require(__DIR__ . '/conf/apiMappings.php');
         $this->versions = require(__DIR__ . '/conf/apiVersions.php');

--- a/src/Controllers/Payment.php
+++ b/src/Controllers/Payment.php
@@ -265,7 +265,7 @@ class Payment extends Controller
         switch ($paymentType) {
             case 'pending':
                 $version = $this->main()->GetEndpointVersion('REQUEST_ORDER');
-                $endpoint = "/${version}" . $main->GetEndpoint('REQUEST_ORDER') . "/$merchantPaymentId";
+                $endpoint = "/{$version}" . $main->GetEndpoint('REQUEST_ORDER') . "/$merchantPaymentId";
                 $url = $this->api_url . $main->GetEndpoint('REQUEST_ORDER') . "/$merchantPaymentId";
                 $url = str_replace('v2', $version, $url);
                 break;

--- a/src/core/ClientControllerException.php
+++ b/src/core/ClientControllerException.php
@@ -42,6 +42,6 @@ class ClientControllerException extends Exception
         $code = $resultInfo["code"];
         $codeId = $resultInfo["codeId"];
         $apiName = $this->apiInfo["api_name"];
-        return "${documentationUrl}?api_name=${apiName}&code=${code}&code_id=${codeId}";
+        return "{$documentationUrl}?api_name={$apiName}&code={$code}&code_id={$codeId}";
     }
 }

--- a/src/core/Model.php
+++ b/src/core/Model.php
@@ -38,10 +38,10 @@ class Model
             }
             if ($memberInfo['type'] === 'string') {
                 if (strlen($member) < 1) {
-                    throw new ModelException("${memberName} cannot be empty", 1, [$memberName]);
+                    throw new ModelException("{$memberName} cannot be empty", 1, [$memberName]);
                 }
                 if (isset($memberInfo['strlen']) && $memberInfo['strlen'] !== 0 && strlen($member) > $memberInfo['strlen']) {
-                    throw new ModelException("${memberName} exceeds maximum size of  characters", 1, [$memberName]);
+                    throw new ModelException("{$memberName} exceeds maximum size of  characters", 1, [$memberName]);
                 }
             }
         }

--- a/tests/CoreClassesTest.php
+++ b/tests/CoreClassesTest.php
@@ -32,7 +32,7 @@ class CoreClassesTest extends BoilerplateTest
         $collector["ENDPOINT_VERSION"] = $client->GetEndpointVersion('SUBSCRIPTION');
         $collector["MERCHANT_ID"] = $client->GetMid();
         foreach ($collector as $key => $value) {
-            $this->assertNotNull($value, "${key} invalid");
+            $this->assertNotNull($value, "{$key} invalid");
         }
     }
     public function testClientBadNwClient()
@@ -68,7 +68,7 @@ class CoreClassesTest extends BoilerplateTest
         $collector["ENDPOINT_VERSION"] = $client->GetEndpointVersion('SUBSCRIPTION');
         $collector["MERCHANT_ID"] = $client->GetMid();
         foreach ($collector as $key => $value) {
-            $this->assertNotNull($value, "${key} invalid");
+            $this->assertNotNull($value, "{$key} invalid");
         }
     }
     public function testClientProduction()
@@ -87,7 +87,7 @@ class CoreClassesTest extends BoilerplateTest
         $collector["ENDPOINT_VERSION"] = $client->GetEndpointVersion('SUBSCRIPTION');
         $collector["MERCHANT_ID"] = $client->GetMid();
         foreach ($collector as $key => $value) {
-            $this->assertNotNull($value, "${key} invalid");
+            $this->assertNotNull($value, "{$key} invalid");
         }
     }
     public function testClientTestMode()
@@ -106,7 +106,7 @@ class CoreClassesTest extends BoilerplateTest
         $collector["ENDPOINT_VERSION"] = $client->GetEndpointVersion('SUBSCRIPTION');
         $collector["MERCHANT_ID"] = $client->GetMid();
         foreach ($collector as $key => $value) {
-            $this->assertNotNull($value, "${key} invalid");
+            $this->assertNotNull($value, "{$key} invalid");
         }
     }
     public function testClientNoMid()


### PR DESCRIPTION
https://www.php.net/manual/en/migration82.deprecated.php

> The "${var}" and "${expr}" style of string interpolation is deprecated. Use "$var"/"{$var}" and "{${expr}}", respectively.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](../../paypayopa-sdk-php/blob/master/contributing.md) document?
* [x] Have you read and signed the automated Contributor's License Agreement?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../paypayopa-sdk-php/pulls) for the same update/change?
  * -> Is it not being merged because there's no CLA (#393)?

### Changes to Core Features:

* [ ] Have you successfully ran tests with your changes locally?
